### PR TITLE
Fix consistency of CIDR JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ The CIDR condition matches CIDR IP Ranges. Using this condition would look like 
 ```json
 {
     "conditions": {
-        "remoteIP": {
+        "remoteIPAddress": {
             "type": "CIDRCondition",
             "options": {
                 "cidr": "192.168.0.1/16"


### PR DESCRIPTION
I first thought the field name for CIDR conditions always was ``remoteIpAddress``. When reading the tests code, I realize the field name in context had to match the condition key.

I wonder whether it's necessary to phrase it explicitly, now that I know it :) But at least this tiny fix will help a bit!

Thanks for the awesome library!