### PR TITLE
Fix typos in the example policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ To decide what the answer is, Ladon uses policy documents which can be represent
 ```json
 {
   "description": "One policy to rule them all.",
-  "subjects": ["users:<[peter|ken]>", "users:maria", "groups:admins"],
-  "actions" : ["delete", "<[create|update]>"],
+  "subjects": ["users:<peter|ken>", "users:maria", "groups:admins"],
+  "actions" : ["delete", "<create|update>"],
   "effect": "allow",
   "resources": [
     "resources:articles:<.*>",
@@ -115,7 +115,7 @@ and can answer access requests that look like:
 {
   "subject": "users:peter",
   "action" : "delete",
-  "resource": "resource:articles:ladon-introduction",
+  "resource": "resources:articles:ladon-introduction",
   "context": {
     "remoteIP": "192.168.0.5"
   }
@@ -136,8 +136,8 @@ POSTing it to an artificial HTTP endpoint:
       "https://my-ladon-implementation.localhost/policies" <<EOF
         {
           "description": "One policy to rule them all.",
-          "subjects": ["users:<[peter|ken]>", "users:maria", "groups:admins"],
-          "actions" : ["delete", "<[create|update]>"],
+          "subjects": ["users:<peter|ken>", "users:maria", "groups:admins"],
+          "actions" : ["delete", "<create|update>"],
           "effect": "allow",
           "resources": [
             "resources:articles:<.*>",
@@ -166,7 +166,7 @@ Then we test if "peter" (ip: "192.168.0.5") is allowed to "delete" the "ladon-in
         {
           "subject": "users:peter",
           "action" : "delete",
-          "resource": "resource:articles:ladon-introduction",
+          "resource": "resources:articles:ladon-introduction",
           "context": {
             "remoteIP": "192.168.0.5"
           }


### PR DESCRIPTION
I tested the example policy with a Gin restful server, it doesn't work. It turns out there's couple typo in the example:
1. Should not use square bracket in ``` <[peter|ken]>```, this would match every single character within the bracket but not peter or ken.
2. resource should be resources in ```resource:articles:ladon-introduction```

The below is how I tested the example:

Rest APIs based on Gin
```
package main

import "github.com/gin-gonic/gin"
import "github.com/ory/ladon"
import manager "github.com/ory/ladon/manager/memory"
import "net/http"

var warden = &ladon.Ladon{Manager: manager.NewMemoryManager()}

func main() {
	r := gin.Default()

	r.GET("/ping", func(c *gin.Context) {
		c.JSON(200, gin.H{
			"message": "pong",
		})
	})

	r.POST("/warden", func(c *gin.Context) {
		var req ladon.Request

		if err := c.ShouldBindJSON(&req); err == nil {
			err := warden.IsAllowed(&req)
			if err == nil {
				c.JSON(http.StatusOK, gin.H{"allowed": true})
			} else {
				c.JSON(http.StatusOK, gin.H{"allowed": false, "error": err.Error()})
			}
		}
	})

	r.POST("/policies", func(c *gin.Context) {
		var policy ladon.DefaultPolicy

		if err := c.ShouldBindJSON(&policy); err == nil {
			err := warden.Manager.Create(&policy)
			if err == nil {
				c.JSON(http.StatusOK, gin.H{"success": true})
			} else {
				c.JSON(http.StatusOK, gin.H{"success": false, "error": err.Error()})	
			}
		}
	})

	r.Run(":3000")
}
```
The test I ran, taken from the example:
```
# create policy
$ curl \
>       -X POST \
>       -H "Content-Type: application/json" \
>       -d@- \
>       "http://localhost:3000/policies" <<EOF
>         {
>           "description": "One policy to rule them all.",
>           "subjects": ["users:<[peter|ken]>", "users:maria", "groups:admins"],
>           "actions" : ["delete", "<[create|update]>"],
>           "effect": "allow",
>           "resources": [
>             "resources:articles:<.*>",
>             "resources:printer"
>           ],
>           "conditions": {
>             "remoteIP": {
>                 "type": "CIDRCondition",
>                 "options": {
>                     "cidr": "192.168.0.1/16"
>                 }
>             }
>           }
>         }
> EOF
{"success":true}
```
```
# test policy
$ curl \
>       -X POST \
>       -H "Content-Type: application/json" \
>       -d@- \
>       "http://localhost:3000/warden" <<EOF
>         {
>           "subject": "users:peter",
>           "action" : "delete",
>           "resource": "resource:articles:ladon-introduction",
>           "context": {
>             "remoteIP": "192.168.0.5"
>           }
>         }
> EOF
{"allowed":false,"error":"Request was denied by default"}

# users:p passed
curl \
>       -X POST \
>       -H "Content-Type: application/json" \
>       -d@- \
>       "http://localhost:3000/warden" <<EOF
>         {
>           "subject": "users:p",
>           "action" : "delete",
>           "resource": "resources:articles:ladon-introduction",
>           "context": {
>             "remoteIP": "192.168.0.5"
>           }
>         }
> EOF
{"allowed":true}
```
Now fix the typo and ran again:
```
$ curl \
>       -X POST \
>       -H "Content-Type: application/json" \
>       -d@- \
>       "http://localhost:3000/policies" <<EOF
>         {
>           "description": "One policy to rule them all.",
>           "subjects": ["users:<peter|ken>", "users:maria", "groups:admins"],
>           "actions" : ["delete", "<create|update>"],
>           "effect": "allow",
>           "resources": [
>             "resources:articles:<.*>",
>             "resources:printer"
>           ],
>           "conditions": {
>             "remoteIP": {
>                 "type": "CIDRCondition",
>                 "options": {
>                     "cidr": "192.168.0.1/16"
>                 }
>             }
>           }
>         }
> EOF
{"success":true}

$ curl \
>       -X POST \
>       -H "Content-Type: application/json" \
>       -d@- \
>       "http://localhost:3000/warden" <<EOF
>         {
>           "subject": "users:peter",
>           "action" : "delete",
>           "resource": "resources:articles:ladon-introduction",
>           "context": {
>             "remoteIP": "192.168.0.5"
>           }
>         }
> EOF
{"allowed":true}
```