### PR TITLE
errors: don't add stack for global error instances

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -22,27 +22,27 @@ import (
 
 var (
 	// ErrRequestDenied is returned when an access request can not be satisfied by any policy.
-	ErrRequestDenied = errors.WithStack(&errorWithContext{
+	ErrRequestDenied = &errorWithContext{
 		error:  errors.New("Request was denied by default"),
 		code:   http.StatusForbidden,
 		status: http.StatusText(http.StatusForbidden),
 		reason: "The request was denied because no matching policy was found.",
-	})
+	}
 
 	// ErrRequestForcefullyDenied is returned when an access request is explicitly denied by a policy.
-	ErrRequestForcefullyDenied = errors.WithStack(&errorWithContext{
+	ErrRequestForcefullyDenied = &errorWithContext{
 		error:  errors.New("Request was forcefully denied"),
 		code:   http.StatusForbidden,
 		status: http.StatusText(http.StatusForbidden),
 		reason: "The request was denied because a policy denied request.",
-	})
+	}
 
 	// ErrNotFound is returned when a resource can not be found.
-	ErrNotFound = errors.WithStack(&errorWithContext{
+	ErrNotFound = &errorWithContext{
 		error:  errors.New("Resource could not be found"),
 		code:   http.StatusNotFound,
 		status: http.StatusText(http.StatusNotFound),
-	})
+	}
 )
 
 func NewErrResourceNotFound(err error) error {


### PR DESCRIPTION
When including `errors.WithStack` in ladon's `Err*` exports, any time
this error is returned, its stacktrace will contain the _definition_.

For example, following snippet

    package main

    import (
        "fmt"
        "github.com/ory/ladon"
        "github.com/pkg/errors"
    )

    func main() {
        fmt.Printf("Error: %+v\n", errors.WithStack(ladon.ErrRequestDenied))
    }

will output

    Error: Request was denied by default
    github.com/chef/xx/vendor/github.com/ory/ladon.init
            /Users/stephan/go/src/github.com/chef/xx/vendor/github.com/ory/ladon/errors.go:25
    main.init
            <autogenerated>:1
    runtime.main
            /usr/local/Cellar/go/1.9.2/libexec/src/runtime/proc.go:183
    runtime.goexit
            /usr/local/Cellar/go/1.9.2/libexec/src/runtime/asm_amd64.s:2337
    main.main
            /Users/stephan/go/src/github.com/chef/xx/main.go:11
    runtime.main
            /usr/local/Cellar/go/1.9.2/libexec/src/runtime/proc.go:195

...of which only the second half is helpful.

Without the call in errors.go, the output will only contain the useful
bit:

    Error: Request was denied by default
    main.main
            /Users/stephan/go/src/github.com/chef/xx/main.go:11
    runtime.main
            /usr/local/Cellar/go/1.9.2/libexec/src/runtime/proc.go:195
    runtime.goexit
            /usr/local/Cellar/go/1.9.2/libexec/src/runtime/asm_amd64.s:2337


What do you think? 😃 