### PR TITLE
Fix logger for AuditLoggerInfo when none is provided.

### DIFF
--- a/audit_logger_info.go
+++ b/audit_logger_info.go
@@ -22,17 +22,17 @@ func (a *AuditLoggerInfo) LogRejectedAccessRequest(r *Request, p Policies, d Pol
 	if len(d) > 1 {
 		allowed := joinPoliciesNames(d[0 : len(d)-1])
 		denied := d[len(d)-1].GetID()
-		a.Logger.Printf("policies %s allow access, but policy %s forcefully denied it", allowed, denied)
+		a.logger().Printf("policies %s allow access, but policy %s forcefully denied it", allowed, denied)
 	} else if len(d) == 1 {
 		denied := d[len(d)-1].GetID()
-		a.Logger.Printf("policy %s forcefully denied the access", denied)
+		a.logger().Printf("policy %s forcefully denied the access", denied)
 	} else {
-		a.Logger.Printf("no policy allowed access")
+		a.logger().Printf("no policy allowed access")
 	}
 }
 
 func (a *AuditLoggerInfo) LogGrantedAccessRequest(r *Request, p Policies, d Policies) {
-	a.Logger.Printf("policies %s allow access", joinPoliciesNames(d))
+	a.logger().Printf("policies %s allow access", joinPoliciesNames(d))
 }
 
 func joinPoliciesNames(policies Policies) string {


### PR DESCRIPTION
This commit fixes an issue with the AuditLoggerInfo structure where
a user may fail to provide a logger at the time the struct is instantiated.

The method logger() for the AuditLoggerInfo structure handles this case by
instantiating a default logger that logs to Stderr if no logger instance
is provided. The logger() method simply needs to be used, and this commit
adds that functionality.