### PR TITLE
Add BooleanCondition type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,36 @@ var err = warden.IsAllowed(&ladon.Request{
 }
 ```
 
+##### [Boolean Condition](condition_boolean.go)
+
+Checks if the boolean value passed in the access request's context is identical with the expected boolean value in the policy
+```go
+var pol = &ladon.DefaultPolicy{
+    Conditions: ladon.Conditions{
+        "some-arbitrary-key": &ladon.BooleanCondition{
+            BooleanValue: true,
+        }
+    },
+}
+```
+
+and would match in the following case:
+
+```go
+var err = warden.IsAllowed(&ladon.Request{
+    // ...
+    Context: &ladon.Context{
+        "some-arbitrary-key": true,
+    },
+})
+```
+
+This condition type is particularly useful if you need to assert a policy dynamically on resources for multiple subjects. For example, consider
+if you wanted to enforce policy that only allows individuals that own a resource to view that resource. You'd have to be able to create a Ladon
+policy that permits access to every resource for every subject that enters your system.
+
+With the Boolean Condition type, you can use conditional logic at runtime to create a match for a policy's condition.
+
 ##### [String Match Condition](condition_string_match.go)
 
 Checks if the value passed in the access request's context matches the regular expression that was given initially

--- a/condition_boolean.go
+++ b/condition_boolean.go
@@ -1,7 +1,5 @@
 package ladon
 
-import "github.com/ory/ladon"
-
 /*
 BooleanCondition is used to determine if a boolean context matches an expected
 boolean condition.
@@ -20,7 +18,7 @@ func (c *BooleanCondition) GetName() string {
 
 // Fulfills determines if the BooleanCondition is fulfilled.
 // The BooleanCondition is fulfilled if the provided boolean value matches the conditions boolean value.
-func (c *BooleanCondition) Fulfills(value interface{}, _ *ladon.Request) bool {
+func (c *BooleanCondition) Fulfills(value interface{}, _ *Request) bool {
 	val, ok := value.(bool)
 
 	return ok && val == c.BooleanValue

--- a/condition_boolean.go
+++ b/condition_boolean.go
@@ -1,5 +1,7 @@
 package ladon
 
+import "github.com/ory/ladon"
+
 /*
 BooleanCondition is used to determine if a boolean context matches an expected
 boolean condition.

--- a/condition_boolean.go
+++ b/condition_boolean.go
@@ -1,0 +1,25 @@
+package ladon
+
+/*
+BooleanCondition is used to determine if a boolean context matches an expected
+boolean condition.
+
+BooleanCondition implements the ladon.Condition interface.
+See https://github.com/ory/ladon/blob/master/condition.go
+*/
+type BooleanCondition struct {
+	BooleanValue bool `json:"value"`
+}
+
+// GetName returns the name of the BooleanCondition
+func (c *BooleanCondition) GetName() string {
+	return "BooleanCondition"
+}
+
+// Fulfills determines if the BooleanCondition is fulfilled.
+// The BooleanCondition is fulfilled if the provided boolean value matches the conditions boolean value.
+func (c *BooleanCondition) Fulfills(value interface{}, _ *ladon.Request) bool {
+	val, ok := value.(bool)
+
+	return ok && val == c.BooleanValue
+}


### PR DESCRIPTION
These commits add a BooleanCondition type to Ladon's standard conditions along with some documentation for the main README that describe how to use the BooleanCondition type.

These additions may prove to be useful for issues related to https://github.com/ory/hydra/issues/590.