### PR TITLE
sql: Ensure regex is only used when a regular expression is present

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,14 +4,17 @@
 [[projects]]
   branch = "master"
   name = "github.com/Azure/go-ansiterm"
-  packages = [".","winterm"]
+  packages = [
+    ".",
+    "winterm"
+  ]
   revision = "d6e3b3328b783f23731bc4d058875b0371ff8109"
 
 [[projects]]
   name = "github.com/Microsoft/go-winio"
   packages = ["."]
-  revision = "78439966b38d69bf38227fbf57ac8a6fee70f69a"
-  version = "v0.4.5"
+  revision = "67921128fb397dd80339870d2193d6b1e6856fd4"
+  version = "v0.4.8"
 
 [[projects]]
   branch = "master"
@@ -20,10 +23,10 @@
   revision = "cd527374f1e5bff4938207604a14f2e38a9cf512"
 
 [[projects]]
-  name = "github.com/cenk/backoff"
+  name = "github.com/cenkalti/backoff"
   packages = ["."]
-  revision = "61153c768f31ee5f130071d08fc82b85208528de"
-  version = "v1.1.0"
+  revision = "2ea60e5f094469f9e65adb9cd103795b73ae743e"
+  version = "v2.0.0"
 
 [[projects]]
   branch = "master"
@@ -39,7 +42,33 @@
 
 [[projects]]
   name = "github.com/docker/docker"
-  packages = ["api/types","api/types/blkiodev","api/types/container","api/types/filters","api/types/mount","api/types/network","api/types/registry","api/types/strslice","api/types/swarm","api/types/swarm/runtime","api/types/versions","opts","pkg/archive","pkg/fileutils","pkg/homedir","pkg/idtools","pkg/ioutils","pkg/jsonmessage","pkg/longpath","pkg/mount","pkg/pools","pkg/stdcopy","pkg/system","pkg/term","pkg/term/windows"]
+  packages = [
+    "api/types",
+    "api/types/blkiodev",
+    "api/types/container",
+    "api/types/filters",
+    "api/types/mount",
+    "api/types/network",
+    "api/types/registry",
+    "api/types/strslice",
+    "api/types/swarm",
+    "api/types/swarm/runtime",
+    "api/types/versions",
+    "opts",
+    "pkg/archive",
+    "pkg/fileutils",
+    "pkg/homedir",
+    "pkg/idtools",
+    "pkg/ioutils",
+    "pkg/jsonmessage",
+    "pkg/longpath",
+    "pkg/mount",
+    "pkg/pools",
+    "pkg/stdcopy",
+    "pkg/system",
+    "pkg/term",
+    "pkg/term/windows"
+  ]
   revision = "fe8aac6f5ae413a967adb0adad0b54abdfb825c4"
 
 [[projects]]
@@ -51,14 +80,8 @@
 [[projects]]
   name = "github.com/docker/go-units"
   packages = ["."]
-  revision = "0dadbb0345b35ec7ef35e228dabb8de89a65bf52"
-  version = "v0.3.2"
-
-[[projects]]
-  name = "github.com/fsouza/go-dockerclient"
-  packages = ["."]
-  revision = "2ff310040c161b75fa19fb9b287a90a6e03c0012"
-  version = "1.1"
+  revision = "47565b4f722fb6ceae66b95f853feed578a4a51c"
+  version = "v0.3.3"
 
 [[projects]]
   name = "github.com/go-sql-driver/mysql"
@@ -81,19 +104,28 @@
 [[projects]]
   branch = "master"
   name = "github.com/hashicorp/golang-lru"
-  packages = [".","simplelru"]
+  packages = [
+    ".",
+    "simplelru"
+  ]
   revision = "0a025b7e63adc15a622f29b0b2c4c3848243bbf6"
 
 [[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
-  packages = [".","reflectx"]
+  packages = [
+    ".",
+    "reflectx"
+  ]
   revision = "3379e5993990b1f927fc8db926485e6f6becf2d2"
 
 [[projects]]
   branch = "master"
   name = "github.com/lib/pq"
-  packages = [".","oid"]
+  packages = [
+    ".",
+    "oid"
+  ]
   revision = "83612a56d3dd153a94a629cd64925371c9adad78"
 
 [[projects]]
@@ -104,27 +136,65 @@
 
 [[projects]]
   name = "github.com/opencontainers/image-spec"
-  packages = ["specs-go","specs-go/v1"]
+  packages = [
+    "specs-go",
+    "specs-go/v1"
+  ]
   revision = "d60099175f88c47cd379c4738d158884749ed235"
   version = "v1.0.1"
 
 [[projects]]
   name = "github.com/opencontainers/runc"
-  packages = ["libcontainer/system","libcontainer/user"]
+  packages = [
+    "libcontainer/system",
+    "libcontainer/user"
+  ]
   revision = "baf6536d6259209c3edfa2b22237af82942d3dfa"
   version = "v0.1.1"
 
 [[projects]]
   name = "github.com/ory/dockertest"
-  packages = ["."]
-  revision = "0c237abec5aabb10bde95a5385d008ce4900accf"
-  version = "v3.1.0"
+  packages = [
+    ".",
+    "docker",
+    "docker/opts",
+    "docker/pkg/archive",
+    "docker/pkg/fileutils",
+    "docker/pkg/homedir",
+    "docker/pkg/idtools",
+    "docker/pkg/ioutils",
+    "docker/pkg/jsonmessage",
+    "docker/pkg/longpath",
+    "docker/pkg/mount",
+    "docker/pkg/pools",
+    "docker/pkg/stdcopy",
+    "docker/pkg/system",
+    "docker/pkg/term",
+    "docker/pkg/term/windows",
+    "docker/types",
+    "docker/types/blkiodev",
+    "docker/types/container",
+    "docker/types/filters",
+    "docker/types/mount",
+    "docker/types/network",
+    "docker/types/registry",
+    "docker/types/strslice",
+    "docker/types/versions"
+  ]
+  revision = "9bca068bf5e4af2484b9c2e8cfeb3d098d5327d7"
+  version = "v3.3.1"
 
 [[projects]]
   name = "github.com/ory/pagination"
   packages = ["."]
   revision = "abd7ec33a01fdec119267449c8f3bad187f881f6"
   version = "v0.0.1"
+
+[[projects]]
+  name = "github.com/ory/sqlcon"
+  packages = ["dockertest"]
+  revision = "7cb5a0f3099d9596e71128202e4bd54405927dfa"
+  version = "v0.0.3"
 
 [[projects]]
   name = "github.com/pborman/uuid"
@@ -147,18 +217,24 @@
 [[projects]]
   branch = "master"
   name = "github.com/rubenv/sql-migrate"
-  packages = [".","sqlparse"]
+  packages = [
+    ".",
+    "sqlparse"
+  ]
   revision = "6edbfbd6a369ee82463312ec67b2c92f97a1d4dc"
 
 [[projects]]
   name = "github.com/sirupsen/logrus"
   packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
+  revision = "c155da19408a8799da419ed3eeb0cb5db0ad5dbc"
+  version = "v1.0.5"
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -171,13 +247,19 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp"]
+  packages = [
+    "context",
+    "context/ctxhttp"
+  ]
   revision = "c7086645de248775cbf2373cf5ca4d2fa664b8c1"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = [
+    "unix",
+    "windows"
+  ]
   revision = "4ff8c001ce4cc464e644b922325097228fce14d8"
 
 [[projects]]
@@ -189,6 +271,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ddc10960fe98c2bffe0dbc5cea519c599973bfa9f5c1a5d3f224455e7566b94b"
+  inputs-digest = "d412c12bcd4f082e633f5c0e547fd745ad6d93c33099d7cc9f14a55b44847cab"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/manager/sql/manager_sql.go
+++ b/manager/sql/manager_sql.go
@@ -185,7 +185,7 @@ func (s *SQLManager) create(policy Policy, tx *sqlx.Tx) (err error) {
 				return errors.WithStack(err)
 			}
 
-			if _, err := tx.Exec(s.db.Rebind(query), id, template, compiled.String(), strings.Index(template, string(policy.GetStartDelimiter())) >= -1); err != nil {
+			if _, err := tx.Exec(s.db.Rebind(query), id, template, compiled.String(), strings.Index(template, string(policy.GetStartDelimiter())) > -1); err != nil {
 				return errors.WithStack(err)
 			}
 			if _, err := tx.Exec(s.db.Rebind(queryRel), policy.GetID(), id); err != nil {

--- a/manager/sql/manager_sql_test.go
+++ b/manager/sql/manager_sql_test.go
@@ -21,22 +21,22 @@
 package sql_test
 
 import (
-	"fmt"
 	"flag"
+	"fmt"
 	"log"
 	"testing"
 
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/jmoiron/sqlx"
+	_ "github.com/lib/pq"
+	"github.com/ory/ladon"
 	"github.com/ory/ladon/manager/sql"
 	"github.com/ory/sqlcon/dockertest"
-	"github.com/ory/ladon"
-	"github.com/jmoiron/sqlx"
 	"github.com/stretchr/testify/require"
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/lib/pq"
 )
 
 type testDB struct {
-	m *sql.SQLManager
+	m  *sql.SQLManager
 	db *sqlx.DB
 }
 
@@ -91,12 +91,12 @@ func TestCreateExplicitPolicy(t *testing.T) {
 	for k, v := range managers {
 		id := "test-explicit"
 		p := &ladon.DefaultPolicy{
-			Actions: []string{"view", "edit"},
+			Actions:     []string{"view", "edit"},
 			Description: "An explicit (non-regex) test policy",
-			Effect: ladon.AllowAccess,
-			ID: id,
-			Resources: []string{"blog:post:1"},
-			Subjects: []string{"otto"},
+			Effect:      ladon.AllowAccess,
+			ID:          id,
+			Resources:   []string{"blog:post:1"},
+			Subjects:    []string{"otto"},
 		}
 		err := v.m.Create(p)
 		require.NoError(t, err)
@@ -108,12 +108,12 @@ func TestCreateRegexPolicy(t *testing.T) {
 	for k, v := range managers {
 		id := "test-regex"
 		p := &ladon.DefaultPolicy{
-			Actions: []string{"<(view|edit)>"},
+			Actions:     []string{"<(view|edit)>"},
 			Description: "An regex test policy",
-			Effect: ladon.AllowAccess,
-			ID: id,
-			Resources: []string{"blog:post:<.*>"},
-			Subjects: []string{"<(otto|hugo)>"},
+			Effect:      ladon.AllowAccess,
+			ID:          id,
+			Resources:   []string{"blog:post:<.*>"},
+			Subjects:    []string{"<(otto|hugo)>"},
 		}
 		err := v.m.Create(p)
 		require.NoError(t, err)

--- a/manager/sql/manager_sql_test.go
+++ b/manager/sql/manager_sql_test.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright © 2016-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright 	2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ */
+
+package sql_test
+
+import (
+	"fmt"
+	"flag"
+	"log"
+	"testing"
+
+	"github.com/ory/ladon/manager/sql"
+	"github.com/ory/sqlcon/dockertest"
+	"github.com/ory/ladon"
+	"github.com/jmoiron/sqlx"
+	"github.com/stretchr/testify/require"
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/lib/pq"
+)
+
+type testDB struct {
+	m *sql.SQLManager
+	db *sqlx.DB
+}
+
+type testQuery struct {
+	checkRegexState string
+}
+
+var queries = map[string]testQuery{
+	"postgres": {
+		checkRegexState: "SELECT COUNT(m.id) FROM %v m JOIN %v r ON m.id = r.%v WHERE r.policy = $1 AND m.has_regex != $2",
+	},
+	"mysql": {
+		checkRegexState: "SELECT COUNT(m.id) FROM %v m JOIN %v r ON m.id = r.%v WHERE r.policy = ? AND m.has_regex != ?",
+	},
+}
+var policyRelations = []string{"action", "resource", "subject"}
+var managers = map[string]testDB{}
+
+func TestMain(m *testing.M) {
+	runner := dockertest.Register()
+
+	flag.Parse()
+	if !testing.Short() {
+		dockertest.Parallel([]func(){
+			func() {
+				db, err := dockertest.ConnectToTestPostgreSQL()
+				if err != nil {
+					log.Fatalf("Could not connect to PostgresSQL database: %v", err)
+					return
+				}
+				s := sql.NewSQLManager(db, nil)
+				s.CreateSchemas("", "")
+				managers["postgres"] = testDB{m: s, db: db}
+			},
+			func() {
+				db, err := dockertest.ConnectToTestMySQL()
+				if err != nil {
+					log.Fatalf("Could not connect to MySQL database: %v", err)
+					return
+				}
+				s := sql.NewSQLManager(db, nil)
+				s.CreateSchemas("", "")
+				managers["mysql"] = testDB{m: s, db: db}
+			},
+		})
+	}
+
+	runner.Exit(m.Run())
+}
+
+func TestCreateExplicitPolicy(t *testing.T) {
+	for k, v := range managers {
+		id := "test-explicit"
+		p := &ladon.DefaultPolicy{
+			Actions: []string{"view", "edit"},
+			Description: "An explicit (non-regex) test policy",
+			Effect: ladon.AllowAccess,
+			ID: id,
+			Resources: []string{"blog:post:1"},
+			Subjects: []string{"otto"},
+		}
+		err := v.m.Create(p)
+		require.NoError(t, err)
+		expectRegexStateForAllRelations(t, k, v, id, false)
+	}
+}
+
+func TestCreateRegexPolicy(t *testing.T) {
+	for k, v := range managers {
+		id := "test-regex"
+		p := &ladon.DefaultPolicy{
+			Actions: []string{"<(view|edit)>"},
+			Description: "An regex test policy",
+			Effect: ladon.AllowAccess,
+			ID: id,
+			Resources: []string{"blog:post:<.*>"},
+			Subjects: []string{"<(otto|hugo)>"},
+		}
+		err := v.m.Create(p)
+		require.NoError(t, err)
+		expectRegexStateForAllRelations(t, k, v, id, true)
+	}
+}
+
+func expectRegexStateForAllRelations(t *testing.T, dbType string, tdb testDB, policyID string, regexState bool) {
+	for _, v := range policyRelations {
+		expectRegexState(t, dbType, tdb, policyID, v, regexState)
+	}
+}
+
+func expectRegexState(t *testing.T, dbType string, tdb testDB, policyID string, rel string, regexState bool) {
+	tbl := fmt.Sprintf("ladon_%v", rel)
+	relTbl := fmt.Sprintf("ladon_policy_%v_rel", rel)
+	query := fmt.Sprintf(queries[dbType].checkRegexState, tbl, relTbl, rel)
+	var count int
+	row := tdb.db.QueryRow(query, policyID, regexState)
+	require.NoError(t, row.Scan(&count))
+	require.Equal(t, 0, count, "Expected has_regex to be %v but got %v entries with a different state", regexState, count)
+}


### PR DESCRIPTION
Hi,

as [discussed in Discord](https://discordapp.com/channels/417987379878428673/417987380302315521/468062922955030528) with @arekkas this PR ensures that the database column `has_regex` on tables `ladon_action`, `ladon_resource` and `ladon_subject` is set to `1` only when a regular expression is really present. A test ensures that the correct value is present in database.

Greets,
Max
