### PR TITLE
Add BooleanCondition to condition factory

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -128,4 +128,7 @@ var ConditionFactories = map[string]func() Condition{
 	new(ResourceContainsCondition).GetName(): func() Condition {
 		return new(ResourceContainsCondition)
 	},
+	new(BooleanCondition).GetName(): func() Condition {
+		return new (BooleanCondition)
+	},
 }

--- a/condition_test.go
+++ b/condition_test.go
@@ -50,9 +50,10 @@ func TestMarshalUnmarshalNative(t *testing.T) {
 
 func TestMarshalUnmarshal(t *testing.T) {
 	css := &Conditions{
-		"clientIP": &CIDRCondition{CIDR: "127.0.0.1/0"},
-		"owner":    &EqualsSubjectCondition{},
-		"role":     &StringMatchCondition{Matches: ".*"},
+		"clientIP":              &CIDRCondition{CIDR: "127.0.0.1/0"},
+		"owner":                 &EqualsSubjectCondition{},
+		"role":                  &StringMatchCondition{Matches: ".*"},
+		"hasElevatedPrivileges": &BooleanCondition{BooleanValue: true},
 	}
 	out, err := json.Marshal(css)
 	require.Nil(t, err)
@@ -75,15 +76,22 @@ func TestMarshalUnmarshal(t *testing.T) {
 			"matches": ".*"
 		}
 	},
+	"hasElevatedPrivileges": {
+		"type": "BooleanCondition",
+		"options": {
+			"value": true
+		}
+	},
 	"resourceFilter": {
 			"type": "ResourceContainsCondition"
 		}
 }`), &cs))
 
-	require.Len(t, cs, 4)
+	require.Len(t, cs, 5)
 	assert.IsType(t, &EqualsSubjectCondition{}, cs["owner"])
 	assert.IsType(t, &CIDRCondition{}, cs["clientIP"])
 	assert.IsType(t, &StringMatchCondition{}, cs["role"])
+	assert.IsType(t, &BooleanCondition{}, cs["hasElevatedPrivileges"])
 	assert.IsType(t, &ResourceContainsCondition{}, cs["resourceFilter"])
 }
 


### PR DESCRIPTION
Signed-off-by: Joshua Anderson Slate <josh.a.slate@gmail.com>

<!--
Before creating your pull request, make sure that you have
[signed the DOC](https://github.com/ory/ladon/blob/master/CONTRIBUTING.md#developers-certificate-of-origin).
You can amend your signature to the current commit using `git commit --amend -s`.

Please create PRs only for bugs, or features that have been discussed with the maintainers, either at the
[ORY Community](https://community.ory.sh/) or join the [ORY Chat](https://www.ory.sh/chat).

If you think you found a security vulnerability, please refrain from posting it publicly on the forums, the chat, or GitHub
and send us an email to [hi@ory.am](mailto:hi@ory.am) instead.
-->
I was attempting to use the `BooleanCondition` last night and noticed I was getting a JSON unmarshaling error. Adding the boolean condition to `ConditionFactories` seems to resolve the issue.