### PR TITLE
feat: support multi-byte regular expression delimiters 

### DIFF
--- a/compiler/regex_test.go
+++ b/compiler/regex_test.go
@@ -47,6 +47,7 @@ func TestRegexCompiler(t *testing.T) {
 
 		{`urn:foo:<user=(?!admin).*>`, '<', '>', false, "urn:foo:user=john", false},
 		{`urn:foo:<user=(?!admin).*>`, '<', '>', false, "urn:foo:user=admin", true},
+		{`urn:foo:user=<(?<=user=).*>`, '<', '>', true, "urn:foo:user=admin", false},
 		{`urn:foo:user=«(?<=user=).*»`, '«', '»', false, "urn:foo:user=admin", false},
 		{`urn:foo:user=«(?<!admin=).*»`, '«', '»', false, "urn:foo:user=admin", false},
 		{`urn:foo:admin=«(?<!admin=).*»`, '«', '»', false, "urn:foo:admin=admin", true},
@@ -65,6 +66,7 @@ func TestRegexCompiler(t *testing.T) {
 		result, err := CompileRegex(c.template, c.delimiterStart, c.delimiterEnd)
 		assert.Equal(t, c.failCompile, err != nil, "Case %d", k)
 		if c.failCompile || err != nil {
+			t.Logf("Case %d failed successfully: %s", k, c.template)
 			continue
 		}
 

--- a/compiler/regex_test.go
+++ b/compiler/regex_test.go
@@ -47,6 +47,9 @@ func TestRegexCompiler(t *testing.T) {
 
 		{`urn:foo:<user=(?!admin).*>`, '<', '>', false, "urn:foo:user=john", false},
 		{`urn:foo:<user=(?!admin).*>`, '<', '>', false, "urn:foo:user=admin", true},
+		{`urn:foo:user=«(?<=user=).*»`, '«', '»', false, "urn:foo:user=admin", false},
+		{`urn:foo:user=«(?<!admin=).*»`, '«', '»', false, "urn:foo:user=admin", false},
+		{`urn:foo:admin=«(?<!admin=).*»`, '«', '»', false, "urn:foo:admin=admin", true},
 
 		{`urn:foo:user=<[[:digit:]]*>`, '<', '>', false, "urn:foo:user=admin", true},
 		{`urn:foo:user=<[[:digit:]]*>`, '<', '>', false, "urn:foo:user=62235", false},


### PR DESCRIPTION
Regular expressions that contain syntax with characters such as: '<','>','{', or '}' will cause issues with the ory/ladon regex compiler. I've made a gentle modification to ladon's regex functions: `delimiterIndices` and `CompileRegex` to support multi-byte delimiters.

I've included test cases and ensured backwards compatibility.