### PR TITLE
chore: remove unused property on RegexpMatcher

### DIFF
--- a/matcher_regexp.go
+++ b/matcher_regexp.go
@@ -44,8 +44,6 @@ func NewRegexpMatcher(size int) *RegexpMatcher {
 
 type RegexpMatcher struct {
 	*lru.Cache
-
-	C map[string]*regexp2.Regexp
 }
 
 func (m *RegexpMatcher) get(pattern string) *regexp2.Regexp {


### PR DESCRIPTION
<!--
Before creating your pull request, make sure that you have
[signed the DOC](https://github.com/ory/ladon/blob/master/CONTRIBUTING.md#developers-certificate-of-origin).
You can amend your signature to the current commit using `git commit --amend -s`.

Please create PRs only for bugs, or features that have been discussed with the maintainers, either at the
[ORY Community](https://community.ory.sh/) or join the [ORY Chat](https://www.ory.sh/chat).

If you think you found a security vulnerability, please refrain from posting it publicly on the forums, the chat, or GitHub
and send us an email to [hi@ory.am](mailto:hi@ory.am) instead.
-->

I think there is a leftover map in the `RegexpMatcher` probably used before moving `lru` cache. AFAIK it could be removed.